### PR TITLE
Fix typo in docs/javascript/null-undefined.md

### DIFF
--- a/docs/javascript/null-undefined.md
+++ b/docs/javascript/null-undefined.md
@@ -25,7 +25,7 @@ console.log(false == undefined); // false
 ```ts
 function foo(arg: string | null | undefined) {
   if (arg != null) {
-    // `!=` がnulllとundefinedを除外しているので、引数argは文字列です
+    // `!=` がnullとundefinedを除外しているので、引数argは文字列です
   }
 }
 ```


### PR DESCRIPTION
`nulll`を`null`に修正いたしました。