### PR TITLE
Fix a typo and some minor interpretation flaws.

### DIFF
--- a/docs/types/interfaces.md
+++ b/docs/types/interfaces.md
@@ -100,4 +100,4 @@ class CrazyClass implements Crazy {
 const crazy = new CrazyClass(); // crazy would be {hello:123}
 ```
 
-あなたはインターフェイスを使ってクレイジーなJSを宣言し、TypeScriptから安全に使用することもできます。しかし、そｒはTypeScriptクラスを使用して、それらを実装できることを意味しているわけではありません。
+インターフェイスを使って世にあるクレイジーなJSを宣言し、TypeScriptから安全に使用することもできます。しかし、それらをTypeScriptクラスとして実装できることを意味しているわけではありません。


### PR DESCRIPTION
「そr」がTypoです。
その他の部分は微妙な解釈かもしれませんので、Typo修正のみでご判断いただいても問題ないかと思います。