### PR TITLE
Fix link from const.md to link.md

### DIFF
--- a/docs/const.md
+++ b/docs/const.md
@@ -37,7 +37,7 @@ foo = 456; // ERROR: Left-hand side of an assignment expression cannot be a cons
 ```
 
 #### ブロックスコープ
-`const`は`let`(./let.md)で見たようにブロックスコープです：
+`const`は[`let`](./let.md)で見たようにブロックスコープです：
 
 ```ts
 const foo = 123;


### PR DESCRIPTION
原文だとconst.mdからlink.mdへのリンクになっていた箇所が、通常のテキストになっていたため、リンクになるようにしました。