### PR TITLE
Fix typo browser page

### DIFF
--- a/docs/quick/browser.md
+++ b/docs/quick/browser.md
@@ -135,7 +135,7 @@ ReactDOM.render(
 > 最新のパッケージを入手するには`npm install typescript@latest react@latest react-dom@latest @types/react@latest @types/react-dom@latest webpack@latest webpack-dev-server@latest webpack-cli@latest ts-loader@latest clean-webpack-plugin@latest html-webpack-plugin@latest --save-exact`を実行してください。
 
 * `npm start`を実行してライブ開発を行います
-    *  [http：//localhost：8080](http：//localhost：8080) を参照してください
+    *  [http://localhost:8080](http://localhost:8080) を参照してください
     * `src/app/app.tsx`(または`src/app/app.tsx`に使われるts/tsxファイル)を編集すれば、サーバーがライブリロードします
     * `src/templates/index.html`を編集すれば、サーバーがライブリロードします
 * `npm run build`を実行して本番用のアセットをビルドします

--- a/docs/quick/browser.md
+++ b/docs/quick/browser.md
@@ -130,7 +130,7 @@ ReactDOM.render(
 );
 ```
 
-# あなたのすばらしいアプリケーションを開発する
+# あなたのすばらしいアプリケーションを開発する {#あなたのすばらしいアプリケーションを開発する}
 
 > 最新のパッケージを入手するには`npm install typescript@latest react@latest react-dom@latest @types/react@latest @types/react-dom@latest webpack@latest webpack-dev-server@latest webpack-cli@latest ts-loader@latest clean-webpack-plugin@latest html-webpack-plugin@latest --save-exact`を実行してください。
 


### PR DESCRIPTION
- URL内のコロンが全角になっていたので半角に修正しました
- 同ページの19行目からのリンクが切れていたので、要素のIDを明示的に指定してリンク切れにならないようにしました