### PR TITLE
Add translation of `complaining`

### DIFF
--- a/docs/types/ambient/variables.md
+++ b/docs/types/ambient/variables.md
@@ -7,7 +7,7 @@ declare var process: any;
 
 > すでに [コミュニティ](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts) が`node.d.ts`をメンテナンスしているので、`process`のためにこれを行う必要はありません。
 
-これにより、TypeScriptを使わずに `process`変数を使うことができます：
+これにより、TypeScriptのエラーが発生することなく`process`変数を使うことができます：
 
 ```ts
 process.exit();


### PR DESCRIPTION
原文
> This allows you to use the `process` variable without TypeScript complaining

内の`complaining`の部分が訳から抜けていると思われたので、追加しました。