### PR TITLE
Improve translation for the "const" page

### DIFF
--- a/docs/const.md
+++ b/docs/const.md
@@ -28,7 +28,7 @@ if (x > maxRows) {
 const foo; // ERROR: const declarations must be initialized
 ```
 
-#### 代入の左辺は定数ではない
+#### 代入の左辺に定数は置けない
 定数は作成後は不変です。したがって、それらを新しい値に代入しようとするとコンパイラエラーになります：
 
 ```ts
@@ -37,7 +37,7 @@ foo = 456; // ERROR: Left-hand side of an assignment expression cannot be a cons
 ```
 
 #### ブロックスコープ
-`const`は[`let`](./let.md)で見たようにブロックスコープです：
+`const`は[`let`](./let.md)と同様にブロックスコープです：
 
 ```ts
 const foo = 123;


### PR DESCRIPTION
- "Left hand side of assignment cannot be a constant"
  - cannot のニュアンスがほしいです。「定数は代入の左辺になれない」とするか迷いましたが、原文の語順を尊重して「置けない」にしました。
- "Block Scoped"
  - 「で見たように」は日本語としてやや不自然なので、意訳してみました。
    - 英語だと主語 we があるおかげで、動詞 saw が不自然には感じられないのではないかな、と思います。