### PR TITLE
Fixes invalid italic words

### DIFF
--- a/intro-1/jest.md
+++ b/intro-1/jest.md
@@ -42,7 +42,7 @@ module.exports = {
 
 説明：
 
-* 私達は\_すべての\_TypeScriptファイルをプロジェクトの`src`フォルダに入れることを常にお勧めします。また、これに倣い`roots`設定では`src`フォルダを指定します。
+* 私達は*すべての*TypeScriptファイルをプロジェクトの`src`フォルダに入れることを常にお勧めします。また、これに倣い`roots`設定では`src`フォルダを指定します。
 * `testMatch`設定は、ts/tsx/jsフォーマットで書かれた.test/.specファイルを発見するためのglobのパターンマッチャーです。
 * `transform`設定は、ts/tsxファイルに対して`ts-jest`を使うよう`jest`に指示します。
 

--- a/type-system/migrating.md
+++ b/type-system/migrating.md
@@ -15,7 +15,7 @@
 
 これらの点のいくつかをさらに議論しましょう。
 
-すべてのJavaScriptは\_有効な\_TypeScriptであることに注意してください。つまり、TypeScriptコンパイラにJavaScriptをいくつか与えると、TypeScriptコンパイラによって生成されたJavaScriptは元のJavaScriptとまったく同じように動作します。つまり、拡張子を`.js`から`.ts`に変更しても、コードベースに悪影響はありません。
+すべてのJavaScriptは*有効な*TypeScriptであることに注意してください。つまり、TypeScriptコンパイラにJavaScriptをいくつか与えると、TypeScriptコンパイラによって生成されたJavaScriptは元のJavaScriptとまったく同じように動作します。つまり、拡張子を`.js`から`.ts`に変更しても、コードベースに悪影響はありません。
 
 ### エラーを抑制する
 


### PR DESCRIPTION
イタリックの属性指定箇所で_のままで表示されている箇所がありました。
* https://typescript-jp.gitbook.io/deep-dive/type-system/migrating
  ![point1](https://user-images.githubusercontent.com/378981/87842062-93715c00-c8e4-11ea-8ee3-bba5e8b2d830.png)
* https://typescript-jp.gitbook.io/deep-dive/intro-1/jest
  ![point2](https://user-images.githubusercontent.com/378981/87842063-94a28900-c8e4-11ea-9927-d6449976e488.png)

_ _ では正しく表現されなかったため、* *で修正してPRを作成しました。

P.S.
大変役に立つ翻訳に感謝します。