### PR TITLE
動作していなかったanchorの修正

### DIFF
--- a/browser.md
+++ b/browser.md
@@ -151,7 +151,7 @@ ReactDOM.render(
 );
 ```
 
-### すばらしいアプリケーションを開発するワークフロー
+### あなたのすばらしいアプリケーションを開発する
 
 > 最新のパッケージを入手するには`npm install typescript@latest react@latest react-dom@latest @types/react@latest @types/react-dom@latest webpack@latest webpack-dev-server@latest webpack-cli@latest ts-loader@latest clean-webpack-plugin@latest html-webpack-plugin@latest --save-exact`を実行してください。
 
@@ -216,4 +216,3 @@ Create React Appでプロジェクトを作成すると、下記のような`tsc
 ## プロジェクトのビルド
 
 `npm run build` または `yarn build` のコマンドで、本番環境用のビルドを実行できます。これで、Reactチームによって本番環境に最適化されたバンドルファイルを出力できます。
-

--- a/docs/quick/browser.md
+++ b/docs/quick/browser.md
@@ -146,7 +146,7 @@ ReactDOM.render(
 );
 ```
 
-# あなたのすばらしいアプリケーションを開発する {#あなたのすばらしいアプリケーションを開発する}
+# あなたのすばらしいアプリケーションを開発する
 
 > 最新のパッケージを入手するには`npm install typescript@latest react@latest react-dom@latest @types/react@latest @types/react-dom@latest webpack@latest webpack-dev-server@latest webpack-cli@latest ts-loader@latest clean-webpack-plugin@latest html-webpack-plugin@latest --save-exact`を実行してください。
 


### PR DESCRIPTION
アンカーのリンク名と、リンク先のタイトルが不一致のため、anchorが動作していなかったのを修正しました。
日本語は「あなたのすばらしいアプリケーションを開発する」の方に揃えました。

(`quick/browser.md ` への移行中だとは思ったのですが、気がついたので送っておきます)