### PR TITLE
エラー解決手順の日本語誤りを修正

### DIFF
--- a/main/common-errors.md
+++ b/main/common-errors.md
@@ -53,6 +53,5 @@ catch (e) {
 
 **修正**：
 
-* `node_modules`と`package-lock`\(またはyarn lock\)と`npm install`をもう一度削除してください。
+* `node_modules`と`package-lock`\(またはyarn lock\)を削除したあと、`npm install`をもう一度実行してください。
 * うまくいかない場合は、無効なモジュールを見つけてください\(あなたのプロジェクトで使われているすべてのモジュールは`react.d.ts`を`peerDependency`とするべきです。hardな`dependency`は持たないようにしてください\)。
-


### PR DESCRIPTION
`npm install` を実行する、という部分が訳されていなかったので修正しました。

原文
```
Delete node_modules and any package-lock (or yarn lock) and npm install again.
```