### PR TITLE
Fix anchor link in styleguide

### DIFF
--- a/styleguide.md
+++ b/styleguide.md
@@ -21,7 +21,7 @@
 * [ファイル名](styleguide.md#filename)
 * [`type` vs `interface`](styleguide.md#type-vs-interface)
 
-## 変数と関数
+## 変数と関数 {#変数と関数}
 
 * 変数と関数名には `camelCase`を使います
 
@@ -41,7 +41,7 @@ var fooVar;
 function barFunc() { }
 ```
 
-## クラス
+## クラス {#クラス}
 
 * クラス名には `PascalCase`を使います。
 
@@ -81,7 +81,7 @@ class Foo {
 }
 ```
 
-## インターフェース
+## インターフェース {#インターフェース}
 
 * 名前には`PascalCase`を使います。
 
@@ -109,7 +109,7 @@ interface Foo {
 }
 ```
 
-## タイプ
+## タイプ {#タイプ}
 
 * 名前には`PascalCase`を使います。
 
@@ -119,7 +119,7 @@ interface Foo {
 
 > 理由：クラスに似ています
 
-## 名前空間
+## 名前空間 {#名前空間}
 
 * 名前に`PascalCase`を使用する
 
@@ -139,7 +139,7 @@ namespace Foo {
 }
 ```
 
-## Enum
+## Enum {#enum}
 
 * enum名には`PascalCase`を使います
 
@@ -179,7 +179,7 @@ enum Color {
 }
 ```
 
-## `null` vs `undefined`
+## `null` vs `undefined` {#null-vs-undefined}
 
 * 明示的に使用不可能にするために、どちらも使用しないことを推奨します。
 
@@ -255,7 +255,7 @@ if (error !== null)
 if (error != undefined)
 ```
 
-## フォーマット
+## フォーマット {#書式設定}
 
 TypeScriptコンパイラには、非常に優れた言語フォーマットのサービスが付属しています。デフォルトで出力される出力は、チームの認知負荷を軽減するのに十分です。
 
@@ -268,7 +268,7 @@ TypeScriptコンパイラには、非常に優れた言語フォーマットの�
 const foo: string = "hello";
 ```
 
-## 引用符
+## 引用符 {#引用符}
 
 * エスケープしない限り、シングルクォート\(`'`\)を使用することをお勧めします。
 
@@ -280,31 +280,31 @@ const foo: string = "hello";
 
 > 理由：これらは一般に、十分複雑な文字列の意図を表しています。
 
-## スペース
+## スペース {#スペース数}
 
 * `2`つのスペースを使います。タブではありません。
 
 > 理由：他のJavaScriptチームがこれを行っています\([airbnb](https://github.com/airbnb/javascript)、[idiomatic](https://github.com/rwaldron/idiomatic.js)、[標準](https://github.com/feross/standard)、[npm](https://github.com/npm/npm)、[node](https://github.com/nodejs/node)、[google/angular](https://github.com/angular/angular/)、[facebook/react](https://github.com/facebook/react)を参照してください\)。 TypeScript/VSCodeチームは4つのスペースを使用しますが、間違いなくエコシステムの例外です。
 
-## セミコロン
+## セミコロン {#セミコロン}
 
 * セミコロンを使用してください。
 
 > 理由：明示的なセミコロンは、言語書式設定ツールで一貫した結果を得るのに役立ちます。Missing ASI\(Automatic semicolon insertion: 自動セミコロン挿入\)は、例えば`foo() \n (function(){})`を単一の文\(2つではなく\)と間違えます。TC39でも同様に勧められています。
 
-## 配列
+## 配列 {#配列}
 
 * 配列に`foos:Array<Foo>`の代わりに`foos:Foo[]`として配列にアノテーションをつけます。
 
 > 理由：読みやすい。TypeScriptチームによって使用されています。脳が`[]`を検出するように訓練されているので、何かが配列であることを知りやすくなります。
 
-## ファイル名
+## ファイル名 {#filename}
 
 `camelCase`を使ってファイルに名前を付けます。例えば`accordion.tsx`、`myControl.tsx`、`utils.ts`、`map.ts`などです。
 
 > 理由：多くのJSチームで慣習的です。
 
-## `type` vs `interface`
+## `type` vs `interface` {#type-vs-interface}
 
 * ユニオン型や交差型が必要な場合には`type`を使います：
 


### PR DESCRIPTION
#93 に沿って[スタイルガイド](https://typescript-jp.gitbook.io/deep-dive/styleguide#%E5%BC%95%E7%94%A8%E7%AC%A6)ページのアンカーを修正しました。
具体的には、各見出しに明示的にIDを付与して対応しています。

#123 の方では`/docs/styleguide/styleguide.md`の方を修正されていたのですが、アクセス出来るスタイルガイドのページは、`/styleguide.md`の方を参照していると思われます。なので`/styleguide.md`の方を修正しました(その場しのぎの対応ですいません。。。)