### PR TITLE
create-react-appの説明を変更

### DIFF
--- a/browser.md
+++ b/browser.md
@@ -168,12 +168,9 @@ TypeScriptを使用してReactのWebアプリケーションを作成する場�
 
 ### 簡単にプロジェクトをセットアップする
 
-まず、Create React Appをインストールします。npmを利用して、`npm i -g create-react-app`というコマンドでローカルPCにグローバルにインストールできます。
-
-Create React Appのインストールができたら、[Reactの公式Webサイト](https://reactjs.org/docs/static-type-checking.html#using-typescript-with-create-react-app)に書かれているように`npx create-react-app my-app --template typescript`というコマンドを実行します。`my-app`の部分には、プロジェクトに利用するフォルダ名を指定します。これで、最初からTypeScriptを利用可能なプロジェクトを簡単に作成できます。
+[Reactの公式Webサイト](https://reactjs.org/docs/static-type-checking.html#using-typescript-with-create-react-app)に書かれているように`npx create-react-app my-app --template typescript`というコマンドを実行します。`my-app`の部分には、プロジェクトに利用するフォルダ名を指定します。これで、最初からTypeScriptを利用可能なプロジェクトを簡単に作成できます。
 
 ```text
-npm i -g create-react-app
 npx create-react-app my-app --template typescript
 cd my-app
 npm start # または、yarn start


### PR DESCRIPTION
いつもこちらのサイトでTypeScriptを学ばせていただいています、ありがとうございます！

[Create React Appのドキュメント](https://create-react-app.dev/docs/getting-started)の中で、`create-react-app`をグローバルにインストールしている場合は、`npx`が常に最新版を使うためにグローバルにインストールした`create-react-app`をアンインストールすることがおすすめされていたので、それに合わせる形に修正した方がいいかと思いました！

>If you've previously installed create-react-app globally via npm install -g create-react-app, we recommend you uninstall the package using npm uninstall -g create-react-app or yarn global remove create-react-app to ensure that npx always uses the latest version.

よろしくお願いします！